### PR TITLE
Emit finished event when writable is finished

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,15 +26,24 @@ module.exports = function soxStream(opts) {
 
 		var sox = cp.spawn(opts.soxPath || 'sox', args)
 		sox.stdout.pipe(soxOutput)
-		sox.stdout.on('finish', tmpFile.cleanup)
+		sox.stdout.on('finish', function () {
+            cleanupThenEmit('finish', null);
+		})
 		sox.stderr.on('data', function (chunk) {
 			cleanupThenEmitErr(new Error(chunk))
 		})
 		sox.on('error', cleanupThenEmitErr)
 	})
 
+	function cleanupThenEmit(event, data) {
+		tmpFile.cleanup(function() {
+			duplex.emit(event, data)
+		})
+	}
+	
 	function cleanupThenEmitErr(err) {
-		tmpFile.cleanup(emitErr.bind(null, err))
+		if (!(err instanceof Error)) err = new Error(err)
+        cleanupThenEmit('error', err)
 	}
 
 	function emitErr(err) {

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ module.exports = function soxStream(opts) {
 		var sox = cp.spawn(opts.soxPath || 'sox', args)
 		sox.stdout.pipe(soxOutput)
 		sox.stdout.on('finish', function () {
-            cleanupThenEmit('finish', null);
+			cleanupThenEmit('finish', null);
 		})
 		sox.stderr.on('data', function (chunk) {
 			cleanupThenEmitErr(new Error(chunk))
@@ -43,7 +43,7 @@ module.exports = function soxStream(opts) {
 	
 	function cleanupThenEmitErr(err) {
 		if (!(err instanceof Error)) err = new Error(err)
-        cleanupThenEmit('error', err)
+		cleanupThenEmit('error', err)
 	}
 
 	function emitErr(err) {


### PR DESCRIPTION
I carry the `finish` event from sox to the duplex stream, it should do this according to to the streams spec.
I assume there may be other events as well but this is the most useful for determining when it's complete and successful.

I haven't investigated tests yet, but have tested this in an actual project